### PR TITLE
fix(version): handle semver build metadata in firmware version strings

### DIFF
--- a/pkg/service/firmware_update.go
+++ b/pkg/service/firmware_update.go
@@ -201,14 +201,17 @@ func (fu *FirmwareUpdater) CheckAndUpdate(currentVersionStr string) (bool, error
 		return false, nil
 	}
 
-	// Compare versions
-	if latestVersion.Compare(currentVersion) <= 0 {
+	if !latestVersion.IsNewerThan(currentVersion) {
 		fu.log.Infof("Current firmware %s is up to date (latest: %s)", currentVersion, latestVersion)
 		fu.setStatus("idle")
 		return false, nil
 	}
 
-	fu.log.Infof("Newer firmware available: %s (current: %s)", latestVersion, currentVersion)
+	if latestVersion.Compare(currentVersion) > 0 {
+		fu.log.Infof("Newer firmware available: %s (current: %s)", latestVersion, currentVersion)
+	} else {
+		fu.log.Infof("Firmware build metadata changed: %s (current: %s)", latestVersion, currentVersion)
+	}
 
 	// Perform the update
 	if err := fu.PerformUpdate(firmwarePath); err != nil {

--- a/pkg/service/version.go
+++ b/pkg/service/version.go
@@ -15,16 +15,19 @@ const (
 
 // FirmwareVersion represents a semantic version number with optional build and suffix
 type FirmwareVersion struct {
-	Major  int
-	Minor  int
-	Patch  int
-	Build  int    // Optional build number (e.g., -1 in v2.0.0-1-ls)
-	Suffix string // Optional suffix (e.g., "ls" in v2.0.0-1-ls)
-	Raw    string
+	Major         int
+	Minor         int
+	Patch         int
+	Build         int    // Optional build number (e.g., -1 in v2.0.0-1-ls)
+	Suffix        string // Optional suffix (e.g., "ls" in v2.0.0-1-ls)
+	BuildMetadata string // Semver build metadata after "+" (e.g., "alarm" in v1.12.0+alarm); ignored in comparisons
+	Raw           string
 }
 
-// ParseFirmwareVersion parses a version string like "v1.12.0", "1.12.0", or extended
-// formats like "v2.0.0-1-ls" (with optional build number and suffix)
+// ParseFirmwareVersion parses a version string like "v1.12.0", "1.12.0", extended
+// formats like "v2.0.0-1-ls" (with optional build number and suffix), or semver
+// build metadata format like "v1.12.0+alarm". Build metadata after "+" is stored
+// but ignored in version comparisons per the semver spec.
 func ParseFirmwareVersion(versionStr string) (*FirmwareVersion, error) {
 	if versionStr == "" {
 		return nil, fmt.Errorf("version string is empty")
@@ -35,6 +38,13 @@ func ParseFirmwareVersion(versionStr string) (*FirmwareVersion, error) {
 
 	// Remove 'v' prefix if present
 	versionStr = strings.TrimPrefix(versionStr, "v")
+
+	// Strip semver build metadata ("+..."); per semver spec it is ignored in comparisons
+	var buildMetadata string
+	if idx := strings.IndexByte(versionStr, '+'); idx >= 0 {
+		buildMetadata = versionStr[idx+1:]
+		versionStr = versionStr[:idx]
+	}
 
 	// Split into components
 	parts := strings.Split(versionStr, ".")
@@ -87,12 +97,13 @@ func ParseFirmwareVersion(versionStr string) (*FirmwareVersion, error) {
 	}
 
 	return &FirmwareVersion{
-		Major:  major,
-		Minor:  minor,
-		Patch:  patch,
-		Build:  build,
-		Suffix: suffix,
-		Raw:    raw,
+		Major:         major,
+		Minor:         minor,
+		Patch:         patch,
+		Build:         build,
+		Suffix:        suffix,
+		BuildMetadata: buildMetadata,
+		Raw:           raw,
 	}, nil
 }
 
@@ -118,7 +129,8 @@ func (v *FirmwareVersion) IsCompatible() bool {
 	return v.Patch >= MinPatch
 }
 
-// String returns a string representation of the version
+// String returns a string representation of the version.
+// Build metadata (if present) is appended with "+" per semver spec.
 func (v *FirmwareVersion) String() string {
 	s := fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
 	if v.Build > 0 {
@@ -127,12 +139,30 @@ func (v *FirmwareVersion) String() string {
 	if v.Suffix != "" {
 		s += "-" + v.Suffix
 	}
+	if v.BuildMetadata != "" {
+		s += "+" + v.BuildMetadata
+	}
 	return s
+}
+
+// IsNewerThan returns true if this version should replace the installed version.
+// A higher base version always triggers an update. When the base version is equal,
+// an update is also triggered if the build metadata differs — e.g. the device
+// reports v1.12.0 but the available firmware is v1.12.0+alarm.
+func (v *FirmwareVersion) IsNewerThan(installed *FirmwareVersion) bool {
+	cmp := v.Compare(installed)
+	if cmp > 0 {
+		return true
+	}
+	if cmp == 0 {
+		return v.BuildMetadata != installed.BuildMetadata
+	}
+	return false
 }
 
 // Compare compares this version with another version.
 // Returns -1 if v < other, 0 if v == other, 1 if v > other.
-// Comparison order: Major > Minor > Patch > Build
+// Comparison order: Major > Minor > Patch > Build. Suffix and BuildMetadata are ignored.
 func (v *FirmwareVersion) Compare(other *FirmwareVersion) int {
 	if other == nil {
 		return 1

--- a/pkg/service/version_test.go
+++ b/pkg/service/version_test.go
@@ -6,15 +6,16 @@ import (
 
 func TestParseFirmwareVersion(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       string
-		wantMajor   int
-		wantMinor   int
-		wantPatch   int
-		wantBuild   int
-		wantSuffix  string
-		wantErr     bool
-		errContains string
+		name          string
+		input         string
+		wantMajor     int
+		wantMinor     int
+		wantPatch     int
+		wantBuild     int
+		wantSuffix    string
+		wantBuildMeta string
+		wantErr       bool
+		errContains   string
 	}{
 		{
 			name:      "valid version with v prefix",
@@ -117,6 +118,44 @@ func TestParseFirmwareVersion(t *testing.T) {
 			errContains: "invalid version format",
 		},
 		{
+			name:          "semver build metadata only",
+			input:         "v1.12.0+alarm",
+			wantMajor:     1,
+			wantMinor:     12,
+			wantPatch:     0,
+			wantBuildMeta: "alarm",
+			wantErr:       false,
+		},
+		{
+			name:          "semver build metadata without v prefix",
+			input:         "1.12.0+alarm",
+			wantMajor:     1,
+			wantMinor:     12,
+			wantPatch:     0,
+			wantBuildMeta: "alarm",
+			wantErr:       false,
+		},
+		{
+			name:          "semver build metadata with pre-release suffix",
+			input:         "v2.0.0-1-ls+build42",
+			wantMajor:     2,
+			wantMinor:     0,
+			wantPatch:     0,
+			wantBuild:     1,
+			wantSuffix:    "ls",
+			wantBuildMeta: "build42",
+			wantErr:       false,
+		},
+		{
+			name:          "semver build metadata with dot-separated identifiers",
+			input:         "v1.12.0+exp.sha.5114f85",
+			wantMajor:     1,
+			wantMinor:     12,
+			wantPatch:     0,
+			wantBuildMeta: "exp.sha.5114f85",
+			wantErr:       false,
+		},
+		{
 			name:        "invalid major version",
 			input:       "vX.12.0",
 			wantErr:     true,
@@ -170,6 +209,9 @@ func TestParseFirmwareVersion(t *testing.T) {
 			}
 			if got.Suffix != tt.wantSuffix {
 				t.Errorf("ParseFirmwareVersion() Suffix = %v, want %v", got.Suffix, tt.wantSuffix)
+			}
+			if got.BuildMetadata != tt.wantBuildMeta {
+				t.Errorf("ParseFirmwareVersion() BuildMetadata = %v, want %v", got.BuildMetadata, tt.wantBuildMeta)
 			}
 			if got.Raw != tt.input {
 				t.Errorf("ParseFirmwareVersion() Raw = %v, want %v", got.Raw, tt.input)
@@ -281,6 +323,16 @@ func TestFirmwareVersion_String(t *testing.T) {
 			name:    "version with multi-part suffix",
 			version: FirmwareVersion{Major: 1, Minor: 12, Patch: 3, Build: 42, Suffix: "ls-beta"},
 			want:    "v1.12.3-42-ls-beta",
+		},
+		{
+			name:    "version with build metadata",
+			version: FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			want:    "v1.12.0+alarm",
+		},
+		{
+			name:    "version with suffix and build metadata",
+			version: FirmwareVersion{Major: 2, Minor: 0, Patch: 0, Build: 1, Suffix: "ls", BuildMetadata: "build42"},
+			want:    "v2.0.0-1-ls+build42",
 		},
 	}
 
@@ -398,12 +450,90 @@ func TestFirmwareVersion_Compare(t *testing.T) {
 			v2:   &FirmwareVersion{Major: 2, Minor: 3, Patch: 4, Build: 1, Suffix: "ls"},
 			want: 1,
 		},
+		{
+			name: "build metadata ignored: v1.12.0+alarm == v1.12.0",
+			v1:   FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			v2:   &FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			want: 0,
+		},
+		{
+			name: "build metadata ignored: v1.12.0+alarm == v1.12.0+other",
+			v1:   FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			v2:   &FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "other"},
+			want: 0,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.v1.Compare(tt.v2); got != tt.want {
 				t.Errorf("FirmwareVersion.Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirmwareVersion_IsNewerThan(t *testing.T) {
+	tests := []struct {
+		name      string
+		available FirmwareVersion
+		installed FirmwareVersion
+		want      bool
+	}{
+		{
+			name:      "newer base version triggers update",
+			available: FirmwareVersion{Major: 1, Minor: 13, Patch: 0},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			want:      true,
+		},
+		{
+			name:      "same version, no update",
+			available: FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			want:      false,
+		},
+		{
+			name:      "older base version, no update",
+			available: FirmwareVersion{Major: 1, Minor: 11, Patch: 0},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			want:      false,
+		},
+		{
+			name:      "same base, metadata added: v1.12.0+alarm available, v1.12.0 installed",
+			available: FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			want:      true,
+		},
+		{
+			name:      "same base, metadata removed: v1.12.0 available, v1.12.0+alarm installed",
+			available: FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			want:      true,
+		},
+		{
+			name:      "same base and metadata, no update",
+			available: FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			want:      false,
+		},
+		{
+			name:      "same base, different metadata: v1.12.0+alarm vs v1.12.0+other",
+			available: FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "alarm"},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0, BuildMetadata: "other"},
+			want:      true,
+		},
+		{
+			name:      "newer base with metadata beats older base without",
+			available: FirmwareVersion{Major: 1, Minor: 13, Patch: 0, BuildMetadata: "alarm"},
+			installed: FirmwareVersion{Major: 1, Minor: 12, Patch: 0},
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.available.IsNewerThan(&tt.installed); got != tt.want {
+				t.Errorf("FirmwareVersion.IsNewerThan() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
`ParseFirmwareVersion` failed on version strings containing semver build metadata (the `+` separator), e.g. `v1.12.0+alarm`. The patch part `0+alarm` was passed directly to `strconv.Atoi`, returning an error.

The nRF firmware repo has a tag `v1.12.0+alarm` — this would break firmware update detection as soon as that tag name appears in a zip filename.

## Changes

**Parsing (`version.go`):**
- Strip `+...` build metadata before parsing the core version
- Store it in a new `BuildMetadata string` field on `FirmwareVersion`
- `Compare()` already ignored `Suffix`; `BuildMetadata` is likewise ignored (semver spec §10: build metadata has no precedence)
- `String()` emits `+buildMetadata` when set, preserving the original format

**Update logic (`firmware_update.go`):**
- New `IsNewerThan(installed)` method replaces the inline `Compare() <= 0` check
- A higher base version always triggers an update (unchanged)
- When the base version is equal, an update is also triggered if build metadata differs — e.g. device reports `v1.12.0`, available firmware is `v1.12.0+alarm`
- Both directions trigger an update (adding or removing metadata, or changing it)

**Tests:**
- Parse, string, and compare cases for `+`-tagged versions
- `TestFirmwareVersion_IsNewerThan` covering all update/no-update cases

Fixes librescoot/librescoot#chb2