### PR TITLE
feat(ble): generic get:/set: passthrough for settings

### DIFF
--- a/pkg/service/extended_commands.go
+++ b/pkg/service/extended_commands.go
@@ -45,6 +45,10 @@ func (s *Service) handleExtendedCommandMessage(msgType ble.MessageType, absSubTy
 		s.handleLTCCommand(strings.TrimPrefix(cmdStr, "ltc:"))
 	} else if strings.HasPrefix(cmdStr, "cap:") {
 		s.handleCapabilityQuery(strings.TrimPrefix(cmdStr, "cap:"))
+	} else if strings.HasPrefix(cmdStr, "get:") {
+		s.handleSettingsGet(strings.TrimPrefix(cmdStr, "get:"))
+	} else if strings.HasPrefix(cmdStr, "set:") {
+		s.handleSettingsSet(strings.TrimPrefix(cmdStr, "set:"))
 	} else {
 		s.log.Warnf("Unknown extended command prefix: %s", cmdStr)
 		s.sendExtendedResponse("error:unknown command")
@@ -530,6 +534,8 @@ var capabilityMap = map[string][]string{
 	"alarm":   {"enable", "disable", "arm", "disarm", "start", "stop"},
 	"ltc":     {"enable", "disable", "force-enable", "force-disable", "status"},
 	"cap":     {"list"},
+	"get":     {"<key>", "list", "list:<prefix>"},
+	"set":     {"<key>:<value>"},
 }
 
 // handleCapabilityQuery responds with the list of supported extended command features.
@@ -559,4 +565,107 @@ func (s *Service) handleCapabilityQuery(cmd string) {
 	}
 
 	s.sendExtendedResponse("cap:error:unknown command")
+}
+
+// handleSettingsGet processes generic settings reads.
+//
+//	get:<key>         → get:<key>:<value>   (value empty if unset)
+//	get:list          → get:count:<n> then N × get:<key>
+//	get:list:<prefix> → same, filtered by prefix match on the key
+func (s *Service) handleSettingsGet(cmd string) {
+	cmd = strings.TrimSpace(cmd)
+
+	if cmd == "list" || strings.HasPrefix(cmd, "list:") {
+		var prefix string
+		if strings.HasPrefix(cmd, "list:") {
+			prefix = strings.TrimPrefix(cmd, "list:")
+		}
+		schema, err := s.getSettingsSchema()
+		if err != nil {
+			s.log.Warnf("settings schema unavailable: %v", err)
+			s.sendExtendedResponse("get:error:schema unavailable")
+			return
+		}
+		keys := make([]string, 0, len(schema))
+		for k := range schema {
+			if prefix == "" || strings.HasPrefix(k, prefix) {
+				keys = append(keys, k)
+			}
+		}
+		s.sendExtendedResponse(fmt.Sprintf("get:count:%d", len(keys)))
+		for _, k := range keys {
+			s.sendExtendedResponse(fmt.Sprintf("get:%s", k))
+		}
+		return
+	}
+
+	key := cmd
+	if key == "" {
+		s.sendExtendedResponse("get:error:missing key")
+		return
+	}
+	schema, err := s.getSettingsSchema()
+	if err != nil {
+		s.log.Warnf("settings schema unavailable: %v", err)
+		s.sendExtendedResponse("get:error:schema unavailable")
+		return
+	}
+	if _, ok := schema[key]; !ok {
+		s.sendExtendedResponse("get:error:unknown key")
+		return
+	}
+	value, err := s.ipc.HGet("settings", key)
+	if err != nil {
+		s.log.Errorf("Failed to HGET settings %s: %v", key, err)
+		s.sendExtendedResponse("get:error:redis")
+		return
+	}
+	s.sendExtendedResponse(fmt.Sprintf("get:%s:%s", key, value))
+}
+
+// handleSettingsSet processes generic settings writes.
+//
+//	set:<key>:<value> → set:ok:<key> on success, set:error:<reason> otherwise
+//
+// Value is everything after the first colon in the body; colons in the
+// value (URLs, etc.) are preserved.
+func (s *Service) handleSettingsSet(cmd string) {
+	key, value, ok := splitSetPayload(cmd)
+	if !ok {
+		s.sendExtendedResponse("set:error:format (expected set:<key>:<value>)")
+		return
+	}
+
+	schema, err := s.getSettingsSchema()
+	if err != nil {
+		s.log.Warnf("settings schema unavailable: %v", err)
+		s.sendExtendedResponse("set:error:schema unavailable")
+		return
+	}
+	spec, ok := schema[key]
+	if !ok {
+		s.sendExtendedResponse("set:error:unknown key")
+		return
+	}
+	if spec.ReadOnly {
+		s.sendExtendedResponse("set:error:read-only")
+		return
+	}
+	if msg := validateSettingValue(spec, value); msg != "" {
+		s.sendExtendedResponse(fmt.Sprintf("set:error:%s", msg))
+		return
+	}
+
+	if err := s.ipc.HSet("settings", key, value); err != nil {
+		s.log.Errorf("Failed to HSET settings %s: %v", key, err)
+		s.sendExtendedResponse("set:error:redis")
+		return
+	}
+	if _, err := s.ipc.Publish("settings", key); err != nil {
+		// Write landed; consumers just won't react until the next
+		// settings-service replay. Not fatal.
+		s.log.Warnf("Failed to PUBLISH settings %s: %v", key, err)
+	}
+	s.log.Infof("Set %s=%s via BLE", key, value)
+	s.sendExtendedResponse(fmt.Sprintf("set:ok:%s", key))
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -58,6 +58,13 @@ type Service struct {
 	// command, so the USOCK response handler knows to relay the result
 	// back as an extended response.
 	ltcBLEPending bool
+
+	// Cached copy of the settings schema (Redis key `settings:schema`)
+	// for the generic get:/set: extended commands. Lazy-loaded on first
+	// use so bluetooth-service starting before settings-service still
+	// recovers.
+	schemaMu    sync.RWMutex
+	schemaCache map[string]settingSchema
 }
 
 // Fault codes for bluetooth service

--- a/pkg/service/settings_schema.go
+++ b/pkg/service/settings_schema.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// settingSchema mirrors the subset of settings-service's schema that we need
+// for validation. Kept as a local copy to avoid inverting the dependency
+// direction (bluetooth-service should not import settings-service internals).
+type settingSchema struct {
+	Type     string               `json:"type"`
+	Default  any                  `json:"default,omitempty"`
+	Values   []settingSchemaValue `json:"values,omitempty"`
+	Min      *float64             `json:"min,omitempty"`
+	Max      *float64             `json:"max,omitempty"`
+	ReadOnly bool                 `json:"read-only,omitempty"`
+	Pattern  string               `json:"pattern,omitempty"`
+}
+
+type settingSchemaValue struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+const settingsSchemaKey = "settings:schema"
+
+// loadSettingsSchema fetches the schema JSON settings-service publishes at
+// startup and parses it. Callers should cache the result; the schema only
+// changes when settings-service restarts.
+func (s *Service) loadSettingsSchema() (map[string]settingSchema, error) {
+	raw, err := s.ipc.Get(settingsSchemaKey)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", settingsSchemaKey, err)
+	}
+	if raw == "" {
+		return nil, fmt.Errorf("%s is empty (settings-service not ready?)", settingsSchemaKey)
+	}
+	var parsed map[string]settingSchema
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", settingsSchemaKey, err)
+	}
+	return parsed, nil
+}
+
+// getSettingsSchema returns the cached schema, loading it on first use.
+// The cache is invalidated on load failure so a later call retries.
+func (s *Service) getSettingsSchema() (map[string]settingSchema, error) {
+	s.schemaMu.Lock()
+	defer s.schemaMu.Unlock()
+	if s.schemaCache != nil {
+		return s.schemaCache, nil
+	}
+	schema, err := s.loadSettingsSchema()
+	if err != nil {
+		return nil, err
+	}
+	s.schemaCache = schema
+	return schema, nil
+}
+
+// validateSettingValue checks a proposed value against the schema entry.
+// Returns a human-readable error string suitable for a BT response, or ""
+// if the value is acceptable.
+func validateSettingValue(spec settingSchema, value string) string {
+	switch spec.Type {
+	case "bool":
+		if value != "true" && value != "false" {
+			return "invalid bool"
+		}
+	case "int":
+		n, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return "invalid int"
+		}
+		if spec.Min != nil && float64(n) < *spec.Min {
+			return "out of range"
+		}
+		if spec.Max != nil && float64(n) > *spec.Max {
+			return "out of range"
+		}
+	case "float":
+		n, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return "invalid float"
+		}
+		if spec.Min != nil && n < *spec.Min {
+			return "out of range"
+		}
+		if spec.Max != nil && n > *spec.Max {
+			return "out of range"
+		}
+	case "enum":
+		for _, v := range spec.Values {
+			if v.Value == value {
+				return ""
+			}
+		}
+		return "invalid enum"
+	case "url":
+		u, err := url.Parse(value)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return "invalid url"
+		}
+	case "duration":
+		if _, err := time.ParseDuration(value); err != nil {
+			return "invalid duration"
+		}
+	case "string":
+		// pass through, no validation beyond non-empty key/value split
+	default:
+		// Unknown type (future schema extension): accept the raw string to
+		// avoid blocking rollout of new types before this service updates.
+	}
+	return ""
+}
+
+// splitSetPayload parses "<key>:<value>" from the body of a set: command.
+// Value may itself contain colons (URLs, pipe-delimited strings), so we
+// split on the FIRST colon only.
+func splitSetPayload(body string) (key, value string, ok bool) {
+	idx := strings.Index(body, ":")
+	if idx <= 0 || idx == len(body)-1 {
+		return "", "", false
+	}
+	return body[:idx], body[idx+1:], true
+}


### PR DESCRIPTION
Adding a new BT-reachable setting right now means another case in `handleConfigCommand`. settings-service already publishes the full schema to `settings:schema` in Redis, so bluetooth-service can validate generic writes against it and expose every non-read-only setting for free.

## Surface

- `get:<key>` returns the current value
- `get:list[:prefix]` lists schema keys (count + items, paced)
- `set:<key>:<value>` validates type/enum/min/max and `read-only`, then `HSET settings` + `PUBLISH settings <key>`

Value keeps colons verbatim (split on first colon only), so URLs and pipe-delimited strings pass through intact.

Schema is cached lazily so bluetooth-service starting before settings-service still recovers. The existing `config:*` allowlist stays in place for phone-app backward compat.

## Test plan

- [x] Deployed on deep-blue, service running
- [ ] `get:scooter.usb0-policy` returns current value
- [ ] `set:scooter.usb0-policy:auto` writes and vehicle-service reacts within ~1s
- [ ] `set:scooter.usb0-policy:bogus` returns `set:error:invalid enum`
- [ ] `set:dashboard.maps-available:true` returns `set:error:read-only`
- [ ] `set:unknown.key:x` returns `set:error:unknown key`
- [ ] `get:list:scooter.` returns scooter-prefixed keys