### PR TITLE
refactor(redis): migrate to FaultReporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/fxamacker/cbor/v2 v2.9.0
-	github.com/librescoot/redis-ipc v0.11.2
+	github.com/librescoot/redis-ipc v0.14.0
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
-github.com/librescoot/redis-ipc v0.11.2 h1:uUuMUNHS4iuRUADJE6RMzVtBHqjODF2ga5UWGg/z1BU=
-github.com/librescoot/redis-ipc v0.11.2/go.mod h1:uvlJaUd1WzRMjZy7dYCHJ6qphCDeYD5orGK9CLudv1Q=
+github.com/librescoot/redis-ipc v0.14.0 h1:qXh3LIEoA74pRbrN1nb+a4B2F4lazW6aOPYdlEs/4/E=
+github.com/librescoot/redis-ipc v0.14.0/go.mod h1:uvlJaUd1WzRMjZy7dYCHJ6qphCDeYD5orGK9CLudv1Q=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -35,7 +35,7 @@ type Service struct {
 	log             *logger.Logger
 	stopCh          chan struct{}
 	wg              sync.WaitGroup
-	faults          *ipc.FaultSet // Fault tracking
+	faults          *ipc.FaultReporter // Fault tracking
 	serialDevice    string
 	baudRate        int
 	usockHandler    func(*usock.Payload)
@@ -79,10 +79,16 @@ type Service struct {
 
 // Fault codes for bluetooth service
 const (
-	FaultSerialPort     = 1 // Serial port communication error
-	FaultNRFInit        = 2 // nRF52 initialization error
-	FaultFirmwareUpdate = 3 // Firmware update error
+	FaultSerialPort     = 1
+	FaultNRFInit        = 2
+	FaultFirmwareUpdate = 3
 )
+
+var faultDescriptions = map[int]string{
+	FaultSerialPort:     "Serial port communication error",
+	FaultNRFInit:        "nRF52 initialization error",
+	FaultFirmwareUpdate: "Firmware update error",
+}
 
 // New creates a new Service instance
 func New(ipcClient *ipc.Client, log *logger.Logger) *Service {
@@ -90,7 +96,7 @@ func New(ipcClient *ipc.Client, log *logger.Logger) *Service {
 		ipc:    ipcClient,
 		log:    log,
 		stopCh: make(chan struct{}),
-		faults: ipcClient.NewFaultSet("ble:fault", "ble", "fault"),
+		faults: ipcClient.NewFaultReporter("ble"),
 	}
 }
 
@@ -195,24 +201,21 @@ func (s *Service) ReconnectUSock() error {
 	return nil
 }
 
-// SetFault adds a fault code to the fault set
+// SetFault raises a fault. Idempotent: emits nothing if already raised.
 func (s *Service) SetFault(code int) {
-	if err := s.faults.Add(code); err != nil {
-		s.log.Errorf("Failed to add fault %d: %v", code, err)
+	desc, ok := faultDescriptions[code]
+	if !ok {
+		desc = fmt.Sprintf("unknown fault %d", code)
+	}
+	if err := s.faults.Raise(code, desc); err != nil {
+		s.log.Errorf("Failed to raise fault %d: %v", code, err)
 	}
 }
 
-// ClearFault removes a fault code from the fault set
+// ClearFault clears a fault. Idempotent: emits nothing if not raised.
 func (s *Service) ClearFault(code int) {
-	if err := s.faults.Remove(code); err != nil {
-		s.log.Errorf("Failed to remove fault %d: %v", code, err)
-	}
-}
-
-// ClearAllFaults removes all fault codes
-func (s *Service) ClearAllFaults() {
-	if err := s.faults.Clear(); err != nil {
-		s.log.Errorf("Failed to clear faults: %v", err)
+	if err := s.faults.Clear(code); err != nil {
+		s.log.Errorf("Failed to clear fault %d: %v", code, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

bluetooth-service used `FaultSet` only, so BLE faults never reached `events:faults`. Consumers (uplink-service event detector, anyone tailing the stream) couldn't see them at all.

Bumps redis-ipc to v0.14.0 and replaces the `FaultSet` with a `FaultReporter` for group `"ble"`. Adds a code-to-description map so the new stream entries carry a useful description (these previously only lived as comments next to the constants). Drops the unused `ClearAllFaults` wrapper.

`SetFault` / `ClearFault` signatures unchanged for callers in `firmware_update.go` and `service.go`.

## Test plan

- [x] `go vet ./... && go build ./... && go test ./...` green
- [x] ARM cross-compile via `make build`